### PR TITLE
Remove self setting DataContext

### DIFF
--- a/ToastNotifications/NotificationTray.xaml
+++ b/ToastNotifications/NotificationTray.xaml
@@ -6,7 +6,7 @@
     xmlns:toastNotifications="clr-namespace:ToastNotifications"
              x:Class="ToastNotifications.NotificationTray"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             x:Name="selfie">
 	<Grid x:Name="Container">
 		<Grid.Resources>
             <Canvas x:Key="InformationIcon" Width="76" Height="76" Clip="F1 M 0,0L 76,0L 76,76L 0,76L 0,0">
@@ -43,8 +43,8 @@
 				WarningTemplate="{StaticResource WarningTemplate}"
 				ErrorTemplate="{StaticResource ErrorTemplate}"/>
 		</Grid.Resources>
-        <Popup x:Name="Popup" IsOpen="{Binding IsOpen, UpdateSourceTrigger=PropertyChanged}" StaysOpen="True" Placement="Left" AllowsTransparency="True"  >
-			<ItemsControl x:Name="ItemsControl" ItemsSource="{Binding NotificationMessages}" ItemTemplateSelector="{StaticResource NotificationTemplateSelector}"  />
+        <Popup x:Name="Popup" IsOpen="{Binding NotificationsSource.IsOpen, UpdateSourceTrigger=PropertyChanged, ElementName=selfie}" StaysOpen="True" Placement="Left" AllowsTransparency="True"  >
+            <ItemsControl x:Name="ItemsControl" ItemsSource="{Binding NotificationsSource.NotificationMessages,ElementName=selfie}" ItemTemplateSelector="{StaticResource NotificationTemplateSelector}"  />
 		</Popup>
 	</Grid>
 </UserControl>

--- a/ToastNotifications/NotificationTray.xaml.cs
+++ b/ToastNotifications/NotificationTray.xaml.cs
@@ -10,22 +10,9 @@ namespace ToastNotifications
     /// </summary>
     public partial class NotificationTray : UserControl
     {
-        public static readonly DependencyProperty NotificationsSourceProperty = DependencyProperty.Register("NotificationsSource", typeof(NotificationsSource), typeof(NotificationTray), new PropertyMetadata(default(NotificationsSource), NotificationSourceChanged));
-
-        private static void NotificationSourceChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
-        {
-            var control = dependencyObject as NotificationTray;
-            var viewModel = eventArgs.NewValue as NotificationsSource;
-
-            if (control == null || viewModel == null)
-                return;
-
-            control._viewModel = viewModel;
-            control.DataContext = viewModel;
-        }
+        public static readonly DependencyProperty NotificationsSourceProperty = DependencyProperty.Register("NotificationsSource", typeof(NotificationsSource), typeof(NotificationTray), new PropertyMetadata(new NotificationsSource()));
 
         private Window _window;
-        private NotificationsSource _viewModel;
 
         public NotificationTray()
         {
@@ -86,7 +73,8 @@ namespace ToastNotifications
             if (control == null)
                 return;
 
-            _viewModel.Hide(control.Notification.Id);
+            // Check for null just in case binding was lost in between
+            this.NotificationsSource?.Hide(control.Notification.Id);
 
             UpdateBounds();
         }


### PR DESCRIPTION
Quick fix from a bug that happened when setting the notification source more than once.

Solution : 
 - Make the Xaml bindings in NotificationsTray control independent from DataContext by using ElementName
 - Changed the code behind (removed useless callback hard setting the DataContext)
 - Usage of NotificationsSource property instead of private field