### PR TITLE
feat(examples): make examples compile under VS2013

### DIFF
--- a/Examples/BasicUsageExample/MainViewModel.cs
+++ b/Examples/BasicUsageExample/MainViewModel.cs
@@ -13,7 +13,7 @@ namespace BasicUsageExample
             set
             {
                 _notificationSource = value;
-                OnPropertyChanged(nameof(NotificationSource));
+                OnPropertyChanged("NotificationSource");
             }
         }
 
@@ -47,7 +47,7 @@ namespace BasicUsageExample
         protected virtual void OnPropertyChanged(string propertyName = null)
         {
             var handler = PropertyChanged;
-            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            if (handler != null) handler.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Examples/BasicUsageExample/MainWindow.xaml.cs
+++ b/Examples/BasicUsageExample/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace BasicUsageExample
 {
@@ -18,22 +19,22 @@ namespace BasicUsageExample
 
         private void Button_ShowInformationClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowInformation($"{_count++} Information");
+            _vm.ShowInformation(String.Format("{0} Information", _count++));
         }
 
         private void Button_ShowSuccessClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowSuccess($"{_count++} Success");
+            _vm.ShowSuccess(String.Format("{0} Success", _count++));
         }
 
         private void Button_ShowWarningClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowWarning($"{_count++} Warning");
+            _vm.ShowWarning(String.Format("{0} Warning", _count++));
         }
 
         private void Button_ShowErrorClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowError($"{_count++} Error");
+            _vm.ShowError(String.Format("{0} Error", _count++));
         }
     }
 }

--- a/Examples/ConfigurationExample/MainViewModel.cs
+++ b/Examples/ConfigurationExample/MainViewModel.cs
@@ -14,7 +14,7 @@ namespace ConfigurationExample
             set
             {
                 _notificationSource = value;
-                OnPropertyChanged(nameof(NotificationSource));
+                OnPropertyChanged("NotificationSource");
             }
         }
 
@@ -25,8 +25,8 @@ namespace ConfigurationExample
             get { return _popupFlowDirection; }
             set
             {
-                _popupFlowDirection = value; 
-                OnPropertyChanged(nameof(PopupFlowDirection));
+                _popupFlowDirection = value;
+                OnPropertyChanged("PopupFlowDirection");
             }
         }
 
@@ -65,7 +65,7 @@ namespace ConfigurationExample
         protected virtual void OnPropertyChanged(string propertyName = null)
         {
             var handler = PropertyChanged;
-            handler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            if (handler != null) handler.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Examples/ConfigurationExample/MainWindow.xaml.cs
+++ b/Examples/ConfigurationExample/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace ConfigurationExample
 {
@@ -18,22 +19,22 @@ namespace ConfigurationExample
 
         private void Button_ShowInformationClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowInformation($"{_count++} Information");
+            _vm.ShowInformation(String.Format("{0} Information", _count++));
         }
 
         private void Button_ShowSuccessClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowSuccess($"{_count++} Success");
+            _vm.ShowSuccess(String.Format("{0} Success", _count++));
         }
 
         private void Button_ShowWarningClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowWarning($"{_count++} Warning");
+            _vm.ShowWarning(String.Format("{0} Warning", _count++));
         }
 
         private void Button_ShowErrorClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowError($"{_count++} Error");
+            _vm.ShowError(String.Format("{0} Error", _count++));
         }
     }
 }


### PR DESCRIPTION
When trying the library by installing it from NuGet, it is useful to just grab a copy of provided examples to play with. In order to have an easier experience for a larger user base, those examples could build successfully under VS2013 / C# 5, instead of requiring VS2015 / C# 6. 

After all, it could be useful to even have the library itself build under VS2013 / C# 5.