### PR TITLE
Quickfix : make popup window resize when the text is too long 

### DIFF
--- a/Examples/ConfigurationExample/MainWindow.xaml
+++ b/Examples/ConfigurationExample/MainWindow.xaml
@@ -11,6 +11,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="40"/>
+            <RowDefinition Height="40"/>
             <RowDefinition Height="40" />
         </Grid.RowDefinitions>
         
@@ -27,15 +28,16 @@
                                     NotificationsSource="{Binding NotificationSource}" 
                                     PopupFlowDirection="{Binding PopupFlowDirection}" />
         </Grid>
-
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1">
+        <TextBox x:Name="sampleTextInput" Grid.Row="1" />
+        
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
             <RadioButton IsChecked="{Binding Path=PopupFlowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=LeftUp}">LeftUp</RadioButton>
             <RadioButton IsChecked="{Binding Path=PopupFlowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=LeftDown}">LeftDown</RadioButton>
             <RadioButton IsChecked="{Binding Path=PopupFlowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=RightUp}">RightUp</RadioButton>
             <RadioButton IsChecked="{Binding Path=PopupFlowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource EnumBooleanConverter}, ConverterParameter=RightDown}">RightDown</RadioButton>
         </StackPanel>
-
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
+    
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="3">
             <Button Content="Information" Margin="5" Width="100" Click="Button_ShowInformationClick" />
             <Button Content="Success" Margin="5" Width="100" Click="Button_ShowSuccessClick" />
             <Button Content="Warning" Margin="5" Width="100" Click="Button_ShowWarningClick" />

--- a/Examples/ConfigurationExample/MainWindow.xaml.cs
+++ b/Examples/ConfigurationExample/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using ToastNotifications;
 
 namespace ConfigurationExample
 {
@@ -17,24 +18,46 @@ namespace ConfigurationExample
         private int _count = 0;
         private readonly MainViewModel _vm;
 
+        private void ShowInternal(NotificationType type, string message)
+        {
+            message = string.IsNullOrWhiteSpace(message) ? $"{_count++} {type.ToString()}" : message;
+            switch (type)
+            {
+                case NotificationType.Error:
+                    _vm.ShowError(message);
+                    break;
+                case NotificationType.Information:
+                    _vm.ShowInformation(message);
+                    break;
+                case NotificationType.Success:
+                    _vm.ShowSuccess(message);
+                    break;
+                case NotificationType.Warning:
+                    _vm.ShowWarning(message);
+                    break;
+                default:
+                    throw new NotImplementedException($"Following notification type isn't supported : {type}");
+            }
+        }
+
         private void Button_ShowInformationClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowInformation(String.Format("{0} Information", _count++));
+            this.ShowInternal(NotificationType.Information, this.sampleTextInput.Text);
         }
 
         private void Button_ShowSuccessClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowSuccess(String.Format("{0} Success", _count++));
+            this.ShowInternal(NotificationType.Success, this.sampleTextInput.Text);
         }
 
         private void Button_ShowWarningClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowWarning(String.Format("{0} Warning", _count++));
+            this.ShowInternal(NotificationType.Warning, this.sampleTextInput.Text);
         }
 
         private void Button_ShowErrorClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowError(String.Format("{0} Error", _count++));
+            this.ShowInternal(NotificationType.Error, this.sampleTextInput.Text);
         }
     }
 }

--- a/ToastNotifications/NotificationPopupWindow.xaml
+++ b/ToastNotifications/NotificationPopupWindow.xaml
@@ -13,7 +13,8 @@
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
         x:Name="Self"
-        Height="300"  Background="Transparent" >
+        MinHeight="300" 
+        Background="Transparent" >
     <Grid Width="260" x:Name="Container">
         <ContentPresenter Content="{Binding ElementName=Self, Path=PopupContent}" />
     </Grid>


### PR DESCRIPTION
The popup had fixed height with `Height="300"` which went in contradiction with the  `SizeToContent="WidthAndHeight"` in [NotificationPopupWindow.xaml ](https://github.com/raflop/ToastNotifications/blob/master/ToastNotifications/NotificationPopupWindow.xaml), I arbitrary decided to make it auto resize.

I am still not quite sure it fit the library design to have unfixed height, but as it was absolutely necessary for me, I think it might be useful for the others too.

- Quickfix : make popup window resize when the text is too long to be displayed with the given height (300).
- Added : Creating popups with custom text in the sample.