### PR TITLE
.net framework 4.0 compatibility and other changes

### DIFF
--- a/Src/Examples/BasicUsageExample/App.config
+++ b/Src/Examples/BasicUsageExample/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
     </startup>
 </configuration>

--- a/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
+++ b/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BasicUsageExample</RootNamespace>
     <AssemblyName>BasicUsageExample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -64,7 +65,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MainViewModel.cs" />
+    <Compile Include="ToastViewModel.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>

--- a/Src/Examples/BasicUsageExample/MainWindow.xaml
+++ b/Src/Examples/BasicUsageExample/MainWindow.xaml
@@ -5,14 +5,32 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
-            
+
             <RowDefinition Height="40"/>
+            <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1">
+        <DockPanel HorizontalAlignment="Center" Grid.Row="1">
+            <CheckBox Name="cbFreezeOnMouseEnter" Content="FreezeOnMouseEnter" IsChecked="True" Margin="5 2"/>
+            <CheckBox Name="cbShowCloseButton" Content="ShowCloseButton" IsChecked="False" Margin="5 2"/>
+            <TextBlock Text="Notifications are queued" HorizontalAlignment="Right" Margin="20 2 0 0" />
+
+        </DockPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
             <Button Content="Information" Margin="5" Width="100" Click="Button_ShowInformationClick" />
             <Button Content="Success" Margin="5" Width="100" Click="Button_ShowSuccessClick" />
             <Button Content="Warning" Margin="5" Width="100" Click="Button_ShowWarningClick" />
             <Button Content="Error" Margin="5" Width="100" Click="Button_ShowErrorClick" />
+            <Button Margin="5" Width="100" Click="Button_SameContentClick" >
+                <Button.Content>
+                    <StackPanel>
+                        <TextBlock Text="Same content" VerticalAlignment="Center"/>
+                        <TextBlock Text="(click more times)" VerticalAlignment="Center" FontSize="10"/>
+                    </StackPanel>
+                </Button.Content>
+            </Button>
+            <Button Content="Clear" Margin="5" Width="100" Click="Button_ClearClick" />
+            <Button Content="Clear Last" Margin="5" Width="100" Click="Button_ClearLastClick" Name="bClearLast" IsEnabled="False" />
+
         </StackPanel>
     </Grid>
 </Window>

--- a/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
+++ b/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
@@ -52,11 +52,11 @@ namespace BasicUsageExample
             MessageOptions opts = new MessageOptions
             {
                 CloseClickAction = closeAction,
-                Tag = "[This is Tag Value]",
+                Tag = $"[This is Tag Value ({++_count})]",
                 FreezeOnMouseEnter = cbFreezeOnMouseEnter.IsChecked.GetValueOrDefault(),
                 ShowCloseButton = cbShowCloseButton.IsChecked.GetValueOrDefault()
             };
-            lastMessage = $"{_count++} {name}";
+            lastMessage = $"{_count} {name}";
             action(lastMessage, opts);
             bClearLast.IsEnabled = true;
         }
@@ -64,7 +64,7 @@ namespace BasicUsageExample
         private void closeAction(NotificationBase obj)
         {
             var opts = obj.DisplayPart.GetOptions();
-            MessageBox.Show($"Notification close clicked {opts.Tag.ToString()}");
+            _vm.ShowInformation($"Notification close clicked, Tag: {opts.Tag.ToString()}");
         }
 
 

--- a/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
+++ b/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using ToastNotifications.Core;
 
 namespace BasicUsageExample
 {
@@ -11,13 +12,14 @@ namespace BasicUsageExample
         public MainWindow()
         {
             InitializeComponent();
-            DataContext = _vm = new MainViewModel();
+            //DataContext = _vm = new MainViewModel();
+            _vm = new ToastViewModel();
 
             Unloaded += OnUnload;
         }
 
         private int _count = 0;
-        private readonly MainViewModel _vm;
+        private readonly ToastViewModel _vm;
 
         private void OnUnload(object sender, RoutedEventArgs e)
         {
@@ -26,22 +28,71 @@ namespace BasicUsageExample
 
         private void Button_ShowInformationClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowInformation(String.Format("{0} Information", _count++));
+            showMessage(_vm.ShowInformation, "Information");
         }
 
         private void Button_ShowSuccessClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowSuccess(String.Format("{0} Success", _count++));
+            showMessage(_vm.ShowSuccess, "Success");
         }
 
         private void Button_ShowWarningClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowWarning(String.Format("{0} Warning", _count++));
+            showMessage(_vm.ShowWarning, "Warning");
         }
 
         private void Button_ShowErrorClick(object sender, RoutedEventArgs e)
         {
-            _vm.ShowError(String.Format("{0} Error", _count++));
+            showMessage(_vm.ShowError, "Error");
+        }
+
+        string lastMessage;
+        void showMessage(Action<string, MessageOptions> action, string name)
+        {
+            MessageOptions opts = new MessageOptions
+            {
+                CloseClickAction = closeAction,
+                Tag = "[This is Tag Value]",
+                FreezeOnMouseEnter = cbFreezeOnMouseEnter.IsChecked.GetValueOrDefault(),
+                ShowCloseButton = cbShowCloseButton.IsChecked.GetValueOrDefault()
+            };
+            lastMessage = $"{_count++} {name}";
+            action(lastMessage, opts);
+            bClearLast.IsEnabled = true;
+        }
+
+        private void closeAction(NotificationBase obj)
+        {
+            var opts = obj.DisplayPart.GetOptions();
+            MessageBox.Show($"Notification close clicked {opts.Tag.ToString()}");
+        }
+
+
+        private void Button_ClearClick(object sender, RoutedEventArgs e)
+        {
+            _vm.ClearMessages("");
+        }
+
+        private void Button_ClearLastClick(object sender, RoutedEventArgs e)
+        {
+            _vm.ClearMessages(lastMessage);
+            bClearLast.IsEnabled = false;
+        }
+
+        private void Button_SameContentClick(object sender, RoutedEventArgs e)
+        {
+            const string sameContent = "Same Content - not duplicated";
+            _vm.ClearMessages(sameContent);
+            MessageOptions opts = new MessageOptions
+            {
+                CloseClickAction = closeAction,
+                Tag = "[This is Tag Value]",
+                FreezeOnMouseEnter = cbFreezeOnMouseEnter.IsChecked.GetValueOrDefault(),
+                ShowCloseButton = cbShowCloseButton.IsChecked.GetValueOrDefault()
+            };
+            _vm.ShowSuccess(sameContent, opts);
+            lastMessage = sameContent;
+            bClearLast.IsEnabled = true;
         }
     }
 }

--- a/Src/Examples/BasicUsageExample/Properties/Resources.Designer.cs
+++ b/Src/Examples/BasicUsageExample/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace BasicUsageExample.Properties
-{
-
-
+namespace BasicUsageExample.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,48 +22,40 @@ namespace BasicUsageExample.Properties
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("BasicUsageExample.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/Src/Examples/BasicUsageExample/Properties/Settings.Designer.cs
+++ b/Src/Examples/BasicUsageExample/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace BasicUsageExample.Properties
-{
-
-
+namespace BasicUsageExample.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Src/Examples/BasicUsageExample/ToastViewModel.cs
+++ b/Src/Examples/BasicUsageExample/ToastViewModel.cs
@@ -2,29 +2,30 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 using ToastNotifications;
+using ToastNotifications.Core;
 using ToastNotifications.Lifetime;
 using ToastNotifications.Messages;
 using ToastNotifications.Position;
 
 namespace BasicUsageExample
 {
-    public class MainViewModel : INotifyPropertyChanged
+    public class ToastViewModel : INotifyPropertyChanged
     {
         private readonly Notifier _notifier;
 
-        public MainViewModel()
+        public ToastViewModel()
         {
             _notifier = new Notifier(cfg =>
             {
                 cfg.PositionProvider = new WindowPositionProvider(
                     parentWindow: Application.Current.MainWindow, 
-                    corner: Corner.TopRight, 
+                    corner: Corner.BottomRight, 
                     offsetX: 25,  
-                    offsetY: 10);
+                    offsetY: 100);
 
                 cfg.LifetimeSupervisor = new TimeAndCountBasedLifetimeSupervisor(
-                    notificationLifetime: TimeSpan.FromSeconds(3), 
-                    maximumNotificationCount: MaximumNotificationCount.FromCount(5));
+                    notificationLifetime: TimeSpan.FromSeconds(6), 
+                    maximumNotificationCount: MaximumNotificationCount.FromCount(6));
 
                 cfg.Dispatcher = Application.Current.Dispatcher;
 
@@ -43,20 +44,41 @@ namespace BasicUsageExample
             _notifier.ShowInformation(message);
         }
 
+        public void ShowInformation(string message, MessageOptions opts)
+        {
+            _notifier.ShowInformation(message, opts);
+        }
+
         public void ShowSuccess(string message)
         {
             _notifier.ShowSuccess(message);
         }
 
-        public void ShowWarning(string message)
+        public void ShowSuccess(string message, MessageOptions opts)
         {
-            _notifier.ShowWarning(message);
+            _notifier.ShowSuccess(message, opts);
+        }
+
+        internal void ClearMessages(string msg)
+        {
+            _notifier.ClearMessages(msg);
+        }
+
+        public void ShowWarning(string message, MessageOptions opts)
+        {
+            _notifier.ShowWarning(message, opts);
         }
 
         public void ShowError(string message)
         {
             _notifier.ShowError(message);
         }
+
+        public void ShowError(string message, MessageOptions opts)
+        {
+            _notifier.ShowError(message, opts);
+        }
+
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/Src/ToastNotifications.Messages/Core/MessageBase.cs
+++ b/Src/ToastNotifications.Messages/Core/MessageBase.cs
@@ -7,14 +7,17 @@ namespace ToastNotifications.Messages.Core
     public abstract class MessageBase<TDisplayPart> : NotificationBase where TDisplayPart : NotificationDisplayPart
     {
         protected NotificationDisplayPart _displayPart;
-        private readonly MessageOptions _options;
+        internal readonly MessageOptions Options;
 
         public string Message { get; }
 
         public MessageBase(string message, MessageOptions options)
         {
             Message = message;
-            _options = options;
+            if (options == null)
+                Options = new MessageOptions();
+            else
+                Options = options;
         }
 
         public override NotificationDisplayPart DisplayPart => _displayPart ?? (_displayPart = Configure());
@@ -26,7 +29,7 @@ namespace ToastNotifications.Messages.Core
             displayPart.Unloaded += OnUnloaded;
             displayPart.MouseLeftButtonDown += OnLeftMouseDown;
 
-            UpdateDisplayOptions(displayPart, _options);
+            UpdateDisplayOptions(displayPart, Options);
             return displayPart;
         }
 
@@ -38,7 +41,7 @@ namespace ToastNotifications.Messages.Core
 
         private void OnLeftMouseDown(object sender, MouseButtonEventArgs e)
         {
-            _options.NotificationClickAction?.Invoke(this);
+            Options.NotificationClickAction?.Invoke(this);
         }
 
         protected abstract void UpdateDisplayOptions(TDisplayPart displayPart, MessageOptions options);

--- a/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
@@ -19,7 +19,7 @@
             </Rectangle>
 
             <TextBlock x:Name="Text" Text="{Binding Message, Mode=OneTime}" Style="{StaticResource NotificationText}" Grid.Column="1"  />
-            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose">
+            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose" Visibility="Hidden">
                 <Rectangle Style="{StaticResource CloseButtonIcon}" Margin="2">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill" Visual="{StaticResource CloseIcon}" />

--- a/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml.cs
+++ b/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml.cs
@@ -18,9 +18,19 @@ namespace ToastNotifications.Messages.Error
             DataContext = error;
         }
 
+        public override string GetMessage()
+        {
+            return this._viewModel.Message;
+        }
         private void OnClose(object sender, RoutedEventArgs e)
         {
+
             _viewModel.Close();
+        }
+
+        public override MessageOptions GetOptions()
+        {
+            return this._viewModel.Options;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Error/ErrorMessage.cs
+++ b/Src/ToastNotifications.Messages/Error/ErrorMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using ToastNotifications.Core;
 using ToastNotifications.Messages.Core;
 
 namespace ToastNotifications.Messages.Error

--- a/Src/ToastNotifications.Messages/ErrorExtensions.cs
+++ b/Src/ToastNotifications.Messages/ErrorExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ToastNotifications.Messages.Core;
+﻿using ToastNotifications.Core;
+using ToastNotifications.Messages.Core;
 using ToastNotifications.Messages.Error;
 
 namespace ToastNotifications.Messages

--- a/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
@@ -18,7 +18,7 @@
                 </Rectangle.Fill>
             </Rectangle>
             <TextBlock x:Name="Text" Text="{Binding Message, Mode=OneTime}" Style="{StaticResource NotificationText}" Grid.Column="1"  />
-            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose">
+            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose" Visibility="Hidden">
                 <Rectangle Style="{StaticResource CloseButtonIcon}" Margin="2">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill" Visual="{StaticResource CloseIcon}" />

--- a/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml.cs
+++ b/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml.cs
@@ -18,9 +18,19 @@ namespace ToastNotifications.Messages.Information
             DataContext = information;
         }
 
+        public override string GetMessage()
+        {
+            return this._viewModel.Message;
+        }
+
         private void OnClose(object sender, RoutedEventArgs e)
         {
             _viewModel.Close();
+        }
+
+        public override MessageOptions GetOptions()
+        {
+            return this._viewModel.Options;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Information/InformationMessage.cs
+++ b/Src/ToastNotifications.Messages/Information/InformationMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using ToastNotifications.Core;
 using ToastNotifications.Messages.Core;
 
 namespace ToastNotifications.Messages.Information

--- a/Src/ToastNotifications.Messages/InformationExtensions.cs
+++ b/Src/ToastNotifications.Messages/InformationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ToastNotifications.Messages.Core;
+﻿using ToastNotifications.Core;
+using ToastNotifications.Messages.Core;
 using ToastNotifications.Messages.Information;
 
 namespace ToastNotifications.Messages

--- a/Src/ToastNotifications.Messages/Properties/Resources.Designer.cs
+++ b/Src/ToastNotifications.Messages/Properties/Resources.Designer.cs
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 namespace ToastNotifications.Messages.Properties {
+    using System;
     
     
     /// <summary>
@@ -37,7 +38,7 @@ namespace ToastNotifications.Messages.Properties {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if ((resourceMan == null)) {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ToastNotifications.Messages.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }

--- a/Src/ToastNotifications.Messages/Properties/Settings.Designer.cs
+++ b/Src/ToastNotifications.Messages/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ToastNotifications.Messages.Properties
-{
+namespace ToastNotifications.Messages.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
-        public static Settings Default
-        {
-            get
-            {
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
@@ -18,7 +18,7 @@
                 </Rectangle.Fill>
             </Rectangle>
             <TextBlock x:Name="Text" Text="{Binding Message, Mode=OneTime}" Style="{StaticResource NotificationText}" Grid.Column="1"  />
-            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose">
+            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose" Visibility="Hidden">
                 <Rectangle Style="{StaticResource CloseButtonIcon}" Margin="2">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill" Visual="{StaticResource CloseIcon}" />

--- a/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml.cs
+++ b/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml.cs
@@ -18,9 +18,19 @@ namespace ToastNotifications.Messages.Success
             DataContext = success;
         }
 
+        public override string GetMessage()
+        {
+            return this._viewModel.Message;
+        }
+
         private void OnClose(object sender, RoutedEventArgs e)
         {
             _viewModel.Close();
+        }
+
+        public override MessageOptions GetOptions()
+        {
+            return this._viewModel.Options;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Success/SuccessMessage.cs
+++ b/Src/ToastNotifications.Messages/Success/SuccessMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using ToastNotifications.Core;
 using ToastNotifications.Messages.Core;
 
 namespace ToastNotifications.Messages.Success

--- a/Src/ToastNotifications.Messages/SuccessExtensions.cs
+++ b/Src/ToastNotifications.Messages/SuccessExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ToastNotifications.Messages.Core;
+﻿using ToastNotifications.Core;
+using ToastNotifications.Messages.Core;
 using ToastNotifications.Messages.Success;
 
 namespace ToastNotifications.Messages

--- a/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
+++ b/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
@@ -8,10 +8,11 @@
     <OutputType>library</OutputType>
     <RootNamespace>ToastNotifications.Messages</RootNamespace>
     <AssemblyName>ToastNotifications.Messages</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,7 +71,6 @@
     </Compile>
     <Compile Include="Information\InformationMessage.cs" />
     <Compile Include="Core\MessageBase.cs" />
-    <Compile Include="Core\MessageOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
@@ -19,7 +19,7 @@
                 </Rectangle.Fill>
             </Rectangle>
             <TextBlock x:Name="Text" Text="{Binding Message, Mode=OneTime}" Style="{StaticResource NotificationText}" Grid.Column="1"  />
-            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose">
+            <Button x:Name="CloseButton" Style="{StaticResource NotificationCloseButton}"  Padding="1" Grid.Column="2" Click="OnClose" Visibility="Hidden">
                 <Rectangle Style="{StaticResource CloseButtonIcon}" Margin="2">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill" Visual="{StaticResource CloseIcon}" />

--- a/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml.cs
+++ b/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml.cs
@@ -18,9 +18,19 @@ namespace ToastNotifications.Messages.Warning
             DataContext = warning;
         }
 
+        public override string GetMessage()
+        {
+            return this._viewModel.Message;
+        }
+
         private void OnClose(object sender, RoutedEventArgs e)
         {
             _viewModel.Close();
+        }
+
+        public override MessageOptions GetOptions()
+        {
+            return this._viewModel.Options;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Warning/WarningMessage.cs
+++ b/Src/ToastNotifications.Messages/Warning/WarningMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using ToastNotifications.Core;
 using ToastNotifications.Messages.Core;
 
 namespace ToastNotifications.Messages.Warning

--- a/Src/ToastNotifications.Messages/WarningExtensions.cs
+++ b/Src/ToastNotifications.Messages/WarningExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ToastNotifications.Messages.Core;
+﻿using ToastNotifications.Core;
+using ToastNotifications.Messages.Core;
 using ToastNotifications.Messages.Warning;
 
 namespace ToastNotifications.Messages

--- a/Src/ToastNotifications/Core/INotification.cs
+++ b/Src/ToastNotifications/Core/INotification.cs
@@ -11,5 +11,9 @@ namespace ToastNotifications.Core
         void Bind(Action<INotification> closeAction);
 
         void Close();
+
+        string GetMessage();
+
+        bool CanClose { get; set; }
     }
 }

--- a/Src/ToastNotifications/Core/MessageOptions.cs
+++ b/Src/ToastNotifications/Core/MessageOptions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using ToastNotifications.Core;
 
-namespace ToastNotifications.Messages.Core
+namespace ToastNotifications.Core
 {
     public class MessageOptions
     {
@@ -9,5 +9,13 @@ namespace ToastNotifications.Messages.Core
 
         public bool? ShowCloseButton { get; set; }
         public Action<NotificationBase> NotificationClickAction { get; set; }
+
+        public Action<NotificationBase> CloseClickAction { get; set; }
+
+        public object Tag { get; set; }
+
+        public bool FreezeOnMouseEnter { get; set; } = true;
+
+
     }
 }

--- a/Src/ToastNotifications/Core/NotificationBase.cs
+++ b/Src/ToastNotifications/Core/NotificationBase.cs
@@ -6,10 +6,12 @@ namespace ToastNotifications.Core
     {
         private Action<INotification> _closeAction;
 
+        public bool CanClose { get; set; } = true;
+
         public abstract NotificationDisplayPart DisplayPart { get; }
 
         public int Id { get; set; }
-        
+
         public virtual void Bind(Action<INotification> closeAction)
         {
             _closeAction = closeAction;
@@ -17,7 +19,17 @@ namespace ToastNotifications.Core
 
         public virtual void Close()
         {
+            var opts = DisplayPart.GetOptions() as MessageOptions;
+            if (opts != null && opts.CloseClickAction != null)
+            {
+                opts.CloseClickAction(this);
+            }
             _closeAction.Invoke(this);
+        }
+
+        public string GetMessage()
+        {
+            return DisplayPart.GetMessage();
         }
     }
 }

--- a/Src/ToastNotifications/Core/NotificationDisplayPart.cs
+++ b/Src/ToastNotifications/Core/NotificationDisplayPart.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using ToastNotifications.Display;
 
 namespace ToastNotifications.Core
@@ -9,7 +11,7 @@ namespace ToastNotifications.Core
     {
         private readonly NotificationAnimator _animator;
         public INotification Notification { get; protected set; }
-        
+
         protected NotificationDisplayPart()
         {
             _animator = new NotificationAnimator(this, TimeSpan.FromMilliseconds(300), TimeSpan.FromMilliseconds(300));
@@ -17,11 +19,41 @@ namespace ToastNotifications.Core
             Margin = new Thickness(1);
 
             _animator.Setup();
-            
+
             Loaded += OnLoaded;
             MinHeight = 60;
         }
-        
+
+        virtual public MessageOptions GetOptions()
+        {
+            return null;
+        }
+
+        protected override void OnMouseEnter(MouseEventArgs e)
+        {
+            var dc = DataContext as INotification;
+            var opts = dc.DisplayPart.GetOptions();
+            if (opts.FreezeOnMouseEnter)
+            {
+                var bord2 = this.Content as Border;
+                if (bord2 != null)
+                {
+                    if (dc.CanClose)
+                    {
+                        dc.CanClose = false;
+                        var btn = FindChild<Button>(this, "CloseButton");
+                        btn.Visibility = Visibility.Visible;
+                    }
+                }
+            }
+            base.OnMouseEnter(e);
+        }
+
+        virtual public string GetMessage()
+        {
+            return "?";
+        }
+
         public void Bind<TNotification>(TNotification notification) where TNotification : INotification
         {
             Notification = notification;
@@ -36,6 +68,50 @@ namespace ToastNotifications.Core
         public void OnClose()
         {
             _animator.PlayHideAnimation();
+        }
+
+        public static T FindChild<T>(DependencyObject parent, string childName)
+   where T : DependencyObject
+        {
+            // Confirm parent and childName are valid. 
+            if (parent == null) return null;
+
+            T foundChild = null;
+
+            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < childrenCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                // If the child is not of the request child type child
+                T childType = child as T;
+                if (childType == null)
+                {
+                    // recursively drill down the tree
+                    foundChild = FindChild<T>(child, childName);
+
+                    // If the child is found, break so we do not overwrite the found child. 
+                    if (foundChild != null) break;
+                }
+                else if (!string.IsNullOrEmpty(childName))
+                {
+                    var frameworkElement = child as FrameworkElement;
+                    // If the child's name is set for search
+                    if (frameworkElement != null && frameworkElement.Name == childName)
+                    {
+                        // if the child's name is of the request name
+                        foundChild = (T)child;
+                        break;
+                    }
+                }
+                else
+                {
+                    // child element found.
+                    foundChild = (T)child;
+                    break;
+                }
+            }
+
+            return foundChild;
         }
     }
 }

--- a/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
+++ b/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
@@ -102,13 +102,16 @@ namespace ToastNotifications.Display
         private void ShowNotification(INotification notification)
         {
             notification.Bind(Close);
-            _window.ShowNotification(notification.DisplayPart);
+            _window?.ShowNotification(notification.DisplayPart);
         }
 
         private void CloseNotification(INotification notification)
         {
-            notification.DisplayPart.OnClose();
-            DelayAction.Execute(TimeSpan.FromMilliseconds(300), () => _window.CloseNotification(notification.DisplayPart));
+            if (notification != null)
+            {
+                notification.DisplayPart.OnClose();
+                DelayAction.Execute(TimeSpan.FromMilliseconds(300), () => _window?.CloseNotification(notification.DisplayPart));
+            }
         }
 
         private void ShowWindow()

--- a/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
+++ b/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace ToastNotifications.Display
 
         private void RecomputeLayout()
         {
-            Dispatcher.Invoke(() => { ; }, DispatcherPriority.Render);
+            Dispatcher.Invoke(((Action)(() => {; })), DispatcherPriority.Render);
         }
 
         public void SetEjectDirection(EjectDirection ejectDirection)

--- a/Src/ToastNotifications/Lifetime/CloseNotificationEventArgs.cs
+++ b/Src/ToastNotifications/Lifetime/CloseNotificationEventArgs.cs
@@ -1,8 +1,9 @@
-﻿using ToastNotifications.Core;
+﻿using System;
+using ToastNotifications.Core;
 
 namespace ToastNotifications.Lifetime
 {
-    public class CloseNotificationEventArgs
+    public class CloseNotificationEventArgs : EventArgs
     {
         public INotification Notification { get; }
 

--- a/Src/ToastNotifications/Lifetime/CountBasedLifetimeSupervisor.cs
+++ b/Src/ToastNotifications/Lifetime/CountBasedLifetimeSupervisor.cs
@@ -61,6 +61,11 @@ namespace ToastNotifications.Lifetime
         {
         }
 
+
+        public void ClearMessages(string msg)
+        {
+        }
+
         public event EventHandler<ShowNotificationEventArgs> ShowNotificationRequested;
         public event EventHandler<CloseNotificationEventArgs> CloseNotificationRequested;
     }

--- a/Src/ToastNotifications/Lifetime/INotificationsLifeTimeSupervisor.cs
+++ b/Src/ToastNotifications/Lifetime/INotificationsLifeTimeSupervisor.cs
@@ -13,5 +13,7 @@ namespace ToastNotifications.Lifetime
         
         event EventHandler<ShowNotificationEventArgs> ShowNotificationRequested;
         event EventHandler<CloseNotificationEventArgs> CloseNotificationRequested;
+
+        void ClearMessages(string msg);
     }
 }

--- a/Src/ToastNotifications/Notifier.cs
+++ b/Src/ToastNotifications/Notifier.cs
@@ -57,6 +57,10 @@ namespace ToastNotifications
             }
         }
 
+        public void ClearMessages(string msg)
+        {
+            this._lifetimeSupervisor?.ClearMessages(msg);
+        }
 
         private bool _disposed = false;
 

--- a/Src/ToastNotifications/Properties/Resources.Designer.cs
+++ b/Src/ToastNotifications/Properties/Resources.Designer.cs
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 namespace ToastNotifications.Properties {
+    using System;
     
     
     /// <summary>
@@ -37,7 +38,7 @@ namespace ToastNotifications.Properties {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if ((resourceMan == null)) {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ToastNotifications.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }

--- a/Src/ToastNotifications/Properties/Settings.Designer.cs
+++ b/Src/ToastNotifications/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ToastNotifications.Properties
-{
+namespace ToastNotifications.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
-        public static Settings Default
-        {
-            get
-            {
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Src/ToastNotifications/ToastNotifications.csproj
+++ b/Src/ToastNotifications/ToastNotifications.csproj
@@ -8,10 +8,11 @@
     <OutputType>library</OutputType>
     <RootNamespace>ToastNotifications</RootNamespace>
     <AssemblyName>ToastNotifications</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\DisplayOptions.cs" />
+    <Compile Include="Core\MessageOptions.cs" />
     <Compile Include="Notifier.cs" />
     <Compile Include="Position\PositionExtensions.cs" />
     <Compile Include="Utilities\DateTimeNow.cs" />


### PR DESCRIPTION
support .net framework 4
add ClearMessages method (all or message by his text). It allow clear all visible messages, or allow void notification duplicity - by hiding old notification before show new notification with the same message
add GetMessage() (internal) method - getting text
add FreezeOnMouseEnter notification option - Notification do not hide if user enter it with mouse
add ShowCloseButton notification option - Close button ish hidden, it show on mouse enter if FreezeOnMouseEnter
add CanClose (internal) option for single notification - disable automatic close of it
add CloseClickAction Action in Option of Notification
Notifications are Queued, no one is simple closed. Queued notification are show after another notification are closed / hidden
fixed problem with MaximumNotificationCount
add Tag property to MessageOptions
added GetOptions method - allow access Tag property drom Notification option
moved MesageOptions to Core project
Update BasicUsageExample - show new abilities