### PR TITLE
Added null-checks when window might not yet be created

### DIFF
--- a/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
+++ b/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
@@ -83,17 +83,21 @@ namespace ToastNotifications.Display
 
         private void UpdateWindowPosition()
         {
+            if(_window == null)
+                return;
             Point position = _positionProvider.GetPosition(_window.GetWidth(), _window.GetHeight());
             _window.SetPosition(position);
         }
 
         private void UpdateEjectDirection()
         {
-            _window.SetEjectDirection(_positionProvider.EjectDirection);
+            _window?.SetEjectDirection(_positionProvider.EjectDirection);
         }
 
         private void UpdateHeight()
         {
+            if(_window == null)
+                return;
             var height = _positionProvider.GetHeight();
             _window.MinHeight = height;
             _window.Height = height;


### PR DESCRIPTION
Sometimes the `WindowPositionProvider.RequestUpdatePosition` is called
when parent window changed but
`NotificationsDisplaySupervisor.InternalDisplayNotification` hasn't been
called yet. This is slight "UI-Thread-Race-Condition" case (I just named
it ;)) when `InternalDisplayNotification` is called on the dispatcher,
but at the same time an event from main window jumps right before it. As
a result `UpdateHeight` and other methods got invoked before `_window`
is actually created.
So I just added null checks to prevent from NRE happening.