### PR TITLE
Hide the transparent window if all items are removed. 

### DIFF
--- a/Src/ToastNotifications/Display/NotificationsItemsControl.cs
+++ b/Src/ToastNotifications/Display/NotificationsItemsControl.cs
@@ -117,5 +117,10 @@ namespace ToastNotifications.Display
         {
             Items.Remove(notification);
         }
+
+        public int GetItemCount()
+        {
+            return Items.Count;
+        }
     }
 }

--- a/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
+++ b/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
@@ -57,7 +57,18 @@ namespace ToastNotifications.Display
 
         private void RecomputeLayout()
         {
-            Dispatcher.Invoke(((Action)(() => {; })), DispatcherPriority.Render);
+            Dispatcher.Invoke(((Action)(() =>
+            {
+                if (NotificationsList.GetItemCount() == 0)
+                {
+                    this.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    this.Visibility = Visibility.Visible;
+                }
+    
+            })), DispatcherPriority.Render);
         }
 
         public void SetEjectDirection(EjectDirection ejectDirection)


### PR DESCRIPTION
This can remove the transparent vertical bar  when taking screen capture.