### PR TITLE
Fix some item not disappear problem

### DIFF
--- a/Src/ToastNotifications/Lifetime/NotificationsList.cs
+++ b/Src/ToastNotifications/Lifetime/NotificationsList.cs
@@ -11,9 +11,9 @@ namespace ToastNotifications.Lifetime
 
         public NotificationMetaData Add(INotification notification)
         {
-            Interlocked.Increment(ref _id);
-            var metaData = new NotificationMetaData(notification, _id, DateTimeNow.Local.TimeOfDay);
-            this[_id] = metaData;
+            var id = Interlocked.Increment(ref _id);
+            var metaData = new NotificationMetaData(notification, id, DateTimeNow.Local.TimeOfDay);
+            this[id] = metaData;
             return metaData;
         }
     }


### PR DESCRIPTION
When adding notification in multiple thread at the same time, some item will not be added to dict because _id changed to later one.
 
Reason: even the increment operation was locked, the use of _id was not locked.  _id may change in the following lines.