### PR TITLE
Fixes for #101

### DIFF
--- a/Src/ToastNotifications/Lifetime/Clear/ClearByTag.cs
+++ b/Src/ToastNotifications/Lifetime/Clear/ClearByTag.cs
@@ -16,8 +16,19 @@ namespace ToastNotifications.Lifetime.Clear
         public IEnumerable<INotification> GetNotificationsToRemove(NotificationsList notifications)
         {
             var notificationsToRemove = notifications
-                .Where(x => x.Value.Notification.Options.Tag.Equals(_tag))
                 .Select(x => x.Value.Notification)
+                .Where(x =>
+                {
+                    object otherTag = x.Options.Tag;
+                    if (ReferenceEquals(otherTag, null))
+                    {
+                        return ReferenceEquals(_tag, null);
+                    }
+                    else
+                    {
+                        return otherTag.Equals(_tag);
+                    }
+                })
                 .ToList();
 
             return notificationsToRemove;


### PR DESCRIPTION
This fixes the NullReferenceException for if `x.Value.Notification.Options.Tag` is `null` by properly comparing nulls. If any notification's tag is `null`, we will clear it if and only if the tag specified to clear is `null`.