### PR TITLE
Make ToastNotifications play nice over Remote Desktop

### DIFF
--- a/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
+++ b/Src/ToastNotifications/Display/NotificationsWindow.xaml.cs
@@ -61,7 +61,7 @@ namespace ToastNotifications.Display
             {
                 if (NotificationsList.GetItemCount() == 0)
                 {
-                    this.Visibility = Visibility.Collapsed;
+                    this.Visibility = Visibility.Hidden;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #99
Workaround for wonky  WPF/RDP behaviour when using transparency & Visibility.Collapsed in NotificationsWindow.