### PR TITLE
Try to detect when the Visual isn't bound to a PresentationSource

### DIFF
--- a/Src/ToastNotifications/Position/ControlPositionProvider.cs
+++ b/Src/ToastNotifications/Position/ControlPositionProvider.cs
@@ -36,8 +36,21 @@ namespace ToastNotifications.Position
             if (source?.CompositionTarget == null)
                 return new Point(0, 0);
 
+            var elementSource = PresentationSource.FromVisual(_element);
+            if (elementSource == null)
+                return new Point(0, 0);
+
             Matrix transform = source.CompositionTarget.TransformFromDevice;
-            Point location = transform.Transform(_element.PointToScreen(new Point(0, 0)));
+            Point location;
+
+            try
+            {
+                location = transform.Transform(_element.PointToScreen(new Point(0, 0)));
+            }
+            catch (InvalidOperationException)
+            {
+                return new Point(0, 0);
+            }
 
             switch (_corner)
             {


### PR DESCRIPTION
Hi! I'm submitting this in the hopes you may be able to help me understand a problem we're facing and see if this is an appropriate solution.

Our application will sometimes (very rarely) crash inside line 40 in the `element.PointToScreen(...)` call. The stack trace looks like this:

```
Application Unhandled exception
(AppDomain.CurrentDomain.UnhandledException) in Application v1.0.0.0 EXCEPTION
OCCURRED:System.InvalidOperationException: This Visual is not connected to
a PresentationSource.
at System.Windows.Media.Visual.PointToScreen(Point point)
at
ToastNotifications.Position.ControlPositionProvider.GetPosition(Double
actualPopupWidth, Double actualPopupHeight)
```

I believe we see it when our application is up and a user is using Remote Desktop to connect. Looking through the code, I can see that this function would be invoked when the window is moved / resized and my hypothesis is that the remote desktop connection, particularly if the resolutions are different, could be causing some issue.

I don't fully understand the cause, but this ends up resulting in a hard crash of our software because this exception isn't caught. So I'm trying out this approach in a private build of this library but I wanted to open the PR here for discussion in case you can think of a better way to solve it.

Thanks for the library and I'm happy to answer any questions or help out in the solution.

Unfortunately, we cannot reliably reproduce this issue :( We just occasionally get a report from a user that it has crashed.