### PR TITLE
Implementing the option to use multiple LifetimeSupervisors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,57 @@ Any help, suggestions, finding issues, pull requests are really appreciated.
 
 If you crate an enhancement or bug fix to the library, and you would like to share it with the community, please send a pull request
 I will test, merge and release nuget
+
+Author: Alexandre José Heinen
+Feature: Allowing multiple LifetimeSupervisors with different behaviors
+I need to use two different LifetimeSupervisor, one with CountBasedLifetimeSupervisor and other with TimeAndCountBasedLifetimeSupervisor. If I create 2 separated Notifiers the notifications can be displayed over the notifications that are already opened.
+For this I create a way to set multiple LifetimeSupervisors to same Notifiers and same DisplaySupervisor.
+To work correctly the LifetimeSupervisors need to be cached, to pass the same instance.
+Example of how to use:
+
+```
+private static Notifier GenerateNotifier(double notificationLifeTime, Corner notificationPosition)
+{
+    //here I check if the LifetimeSupervisor to use is based on time
+    //if it is null I create new instance
+    if (notificationLifeTime > 0 && _lifetimeTimeAndCount == null)
+    {
+        _lifetimeTimeAndCount = new TimeAndCountBasedLifetimeSupervisor(
+            notificationLifetime: TimeSpan.FromSeconds(notificationLifeTime),
+            maximumNotificationCount: MaximumNotificationCount.FromCount(5));
+    }
+    
+    //here I check if the LifetimeSupervisor to use is based only on count
+    //if it is null I create new instance
+    if (notificationLifeTime == 0 && _lifetimeCount == null)
+    {
+        _lifetimeCount = new CountBasedLifetimeSupervisor(maximumNotificationCount: MaximumNotificationCount.FromCount(5));
+    }
+
+    //get the correct LifetimeSupervisor to use
+    INotificationsLifetimeSupervisor lifetimeSupervisor = notificationLifeTime > 0 ? (INotificationsLifetimeSupervisor)_lifetimeTimeAndCount : (INotificationsLifetimeSupervisor)_lifetimeCount;
+
+    if (_notifier == null)
+    {
+        _notifier = new Notifier(cfg =>
+        {
+            cfg.PositionProvider = new WindowPositionProvider(
+                parentWindow: Application.Current.MainWindow,
+                corner: notificationPosition,
+                offsetX: 10,
+                offsetY: 49);
+
+            cfg.LifetimeSupervisor = lifetimeSupervisor;
+
+            cfg.Dispatcher = Application.Current.Dispatcher;
+        });
+    }
+
+    //update the current LifetimeSupervisor in the notifier
+    _notifier.UpdateLifetimeSupervisor(lifetimeSupervisor);
+
+    return _notifier;
+}
+```
+
+In this case I'm not checking if the notificationLifeTime is different, but if you need you can cache into a dictionary with notificationLifeTime as the key.

--- a/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
+++ b/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
@@ -33,6 +33,7 @@ namespace ToastNotifications.Display
             _displayOptions = displayOptions;
             _keyboardEventHandler = keyboardEventHandler;
             _lifetimeSupervisorList = new List<INotificationsLifetimeSupervisor>();
+            _lifetimeSupervisorList.Add(lifetimeSupervisor);
 
             _lifetimeSupervisor.ShowNotificationRequested += LifetimeSupervisorOnShowNotificationRequested;
             _lifetimeSupervisor.CloseNotificationRequested += LifetimeSupervisorOnCloseNotificationRequested;

--- a/Src/ToastNotifications/Display/NotificationsItemsControl.cs
+++ b/Src/ToastNotifications/Display/NotificationsItemsControl.cs
@@ -110,7 +110,13 @@ namespace ToastNotifications.Display
 
         public void AddNotification(NotificationDisplayPart notification)
         {
-            Items.Add(notification);
+            //Can't find why notifications are tried to add more than one time
+            //Without this condition an error was thrown
+            if (notification.Parent == null)
+            {
+                Items.Add(notification);
+            }
+
         }
 
         public void RemoveNotification(NotificationDisplayPart notification)

--- a/Src/ToastNotifications/Lifetime/CountBasedLifetimeSupervisor.cs
+++ b/Src/ToastNotifications/Lifetime/CountBasedLifetimeSupervisor.cs
@@ -83,6 +83,20 @@ namespace ToastNotifications.Lifetime
             }
         }
 
+        public bool ContainsNotification(INotification notification)
+        {
+            var enumerator = _notifications.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current.Value.Notification == notification)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public event EventHandler<ShowNotificationEventArgs> ShowNotificationRequested;
         public event EventHandler<CloseNotificationEventArgs> CloseNotificationRequested;
     }

--- a/Src/ToastNotifications/Lifetime/INotificationsLifeTimeSupervisor.cs
+++ b/Src/ToastNotifications/Lifetime/INotificationsLifeTimeSupervisor.cs
@@ -7,6 +7,7 @@ namespace ToastNotifications.Lifetime
 {
     public interface INotificationsLifetimeSupervisor : IDisposable
     {
+        bool ContainsNotification(INotification notification);
         void PushNotification(INotification notification);
         void CloseNotification(INotification notification);
 

--- a/Src/ToastNotifications/Lifetime/TimeAndCountBasedLifetimeSupervisor.cs
+++ b/Src/ToastNotifications/Lifetime/TimeAndCountBasedLifetimeSupervisor.cs
@@ -145,6 +145,20 @@ namespace ToastNotifications.Lifetime
             }
         }
 
+        public bool ContainsNotification(INotification notification)
+        {
+            var enumerator = _notifications.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current.Value.Notification == notification)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public event EventHandler<ShowNotificationEventArgs> ShowNotificationRequested;
         public event EventHandler<CloseNotificationEventArgs> CloseNotificationRequested;
     }

--- a/Src/ToastNotifications/Notifier.cs
+++ b/Src/ToastNotifications/Notifier.cs
@@ -76,6 +76,22 @@ namespace ToastNotifications
             _lifetimeSupervisor?.ClearMessages(clearStrategy);
         }
 
+        public void UpdateLifetimeSupervisor(INotificationsLifetimeSupervisor lifetimeSupervisor)
+        {
+            if (_configuration != null)
+            {
+                lock (_syncRoot)
+                {
+                    _configuration.LifetimeSupervisor = lifetimeSupervisor;
+                    _lifetimeSupervisor = lifetimeSupervisor;
+                    _lifetimeSupervisor.UseDispatcher(_configuration.Dispatcher);
+
+                    _displaySupervisor.UpdateLifetimeSupervisor(_lifetimeSupervisor);
+                }
+
+            }
+        }
+
         private bool _disposed = false;
 
         public object SyncRoot => _syncRoot;


### PR DESCRIPTION
Feature: Allowing multiple LifetimeSupervisors with different behaviors
I need to use two different LifetimeSupervisor, one with CountBasedLifetimeSupervisor and other with TimeAndCountBasedLifetimeSupervisor. If I create 2 separated Notifiers the notifications can be displayed over the notifications that are already opened.
For this I create a way to set multiple LifetimeSupervisors to same Notifiers and same DisplaySupervisor.
To work correctly the LifetimeSupervisors need to be cached, to pass the same instance.
Example of how to use:

```
private static Notifier GenerateNotifier(double notificationLifeTime, Corner notificationPosition)
{
    //here I check if the LifetimeSupervisor to use is based on time
    //if it is null I create new instance
    if (notificationLifeTime > 0 && _lifetimeTimeAndCount == null)
    {
        _lifetimeTimeAndCount = new TimeAndCountBasedLifetimeSupervisor(
            notificationLifetime: TimeSpan.FromSeconds(notificationLifeTime),
            maximumNotificationCount: MaximumNotificationCount.FromCount(5));
    }
    
    //here I check if the LifetimeSupervisor to use is based only on count
    //if it is null I create new instance
    if (notificationLifeTime == 0 && _lifetimeCount == null)
    {
        _lifetimeCount = new CountBasedLifetimeSupervisor(maximumNotificationCount: MaximumNotificationCount.FromCount(5));
    }

    //get the correct LifetimeSupervisor to use
    INotificationsLifetimeSupervisor lifetimeSupervisor = notificationLifeTime > 0 ? (INotificationsLifetimeSupervisor)_lifetimeTimeAndCount : (INotificationsLifetimeSupervisor)_lifetimeCount;

    if (_notifier == null)
    {
        _notifier = new Notifier(cfg =>
        {
            cfg.PositionProvider = new WindowPositionProvider(
                parentWindow: Application.Current.MainWindow,
                corner: notificationPosition,
                offsetX: 10,
                offsetY: 49);

            cfg.LifetimeSupervisor = lifetimeSupervisor;

            cfg.Dispatcher = Application.Current.Dispatcher;
        });
    }

    //update the current LifetimeSupervisor in the notifier
    _notifier.UpdateLifetimeSupervisor(lifetimeSupervisor);

    return _notifier;
}
```

In this case I'm not checking if the notificationLifeTime is different, but if you need you can cache into a dictionary with notificationLifeTime as the key.